### PR TITLE
Remove lockfile maintenance 

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,11 +30,13 @@
         "schedule:weekly",
         "default:pinDigestsDisabled",
         "default:separatePatchReleases",
-        "default:maintainLockFilesWeekly",
         "default:semanticCommits",
         "default:rebaseStalePrs",
         "default:preserveSemverRanges"
       ],
+      "lockFileMaintenance": {
+        "enabled": false
+      },
       "labels": [
         "dependencies"
       ],

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.5",
+  "version": "1.1.6",
   "name": "@telusdigital/renovate-config",
   "description": "TELUS preset configs for Renovate",
   "author": "Ahmad Nassri <ahmad.nassri@telus.com> (https://labs.telus.com/)",
@@ -29,6 +29,8 @@
         "config:base",
         "schedule:weekly",
         "default:pinDigestsDisabled",
+        "default:separatePatchReleases",
+        "default:maintainLockFilesWeekly",
         "default:semanticCommits",
         "default:rebaseStalePrs",
         "default:preserveSemverRanges"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description

* Update `master` branch to include changes introduced in latest tag `v1.1.6`
* Remove lockfile maintenance (breaking change)

## Motivation and Context

Lockfile maintenance was discussed as an undesirable feature of Renovate since it would delete and re-create the lockfile. Since most telus repositories use caret versions instead of locked versions, this may upgrade many packages undesirably.

## How Has This Been Tested?

From general usage, teams have been ignoring lockfile maintenance pull requests. No actual testing took place.

## Screenshots (if appropriate):

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bugfix
- [ ] Feature
- [ ] Performance Improvement
- [ ] Tests _(fix, improvement, new tests)_
- [ ] Code style update _(formatting, local variables)_
- [x] Refactoring _(no functional changes, no api changes)_
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other... Please describe: 

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [ ] I have reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
