### PR TITLE
feat(renovate): added timezone configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,16 +34,15 @@
         "default:separatePatchReleases",
         "default:semanticCommits",
         "default:rebaseStalePrs",
-        "default:preserveSemverRanges"
+        "default:preserveSemverRanges",
+        "default:prConcurrentLimitNone",
+        "default:prHourlyLimitNone",
+        "default:timezone(America/Vancouver)",
+        "default:label(dependencies)"
       ],
       "lockFileMaintenance": {
         "enabled": false
       },
-      "labels": [
-        "dependencies"
-      ],
-      "prHourlyLimit": 0,
-      "prConcurrentLimit": 0,
       "ignoreNpmrcFile": true,
       "encrypted": {
         "npmToken": "PhEKXUwZLAbJYcOECUmwS0mMT49WG23AvDt36x9hLrM/wEX7qGCnNHz2e38eNomBMJpubNol2FzcioaS2npiQ7EJMGpNVdAOP98N5aGhl2lVJfSzjpMXrS+rvy/rwWYJGTxyV5BaVf/lpAXTeCDvUqfSXmgFIbkUVGyfSxxD8iiPMVFxpVGVnldW4mYcXbX7K98o3v17zvZKkw7ciIVdN284AHZyBljaI8r4eE15F507RrP4I2trcCTWEmNm3HKy8yGKHVa0ve0YQxA5s5UY0HG2lHTVzUNw3D1hioWoMVdYupGuhQvp/UVk2x3dkPAD3Dp64Q+dr/Ms24p1gDmgkw=="


### PR DESCRIPTION
# Added Timezone Configuration

## Description

- Configure renovate to Vancouver PST timezone
- Replace a few detailed JSON configs with extend syntax

## Motivation and Context

Right now the timezone is in GMT. For daily scheduled jobs, its running while Vancouver developers are still in office.

## How Has This Been Tested?

Renovate validated the syntax on my open source one.

## Types of changes

- [x] Feature
- [x] Refactoring

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [ ] I have reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
