### PR TITLE
feat(rebase): don't rebase stale PRs

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
         "default:pinDigestsDisabled",
         "default:separatePatchReleases",
         "default:semanticCommits",
-        "default:rebaseStalePrs",
         "default:preserveSemverRanges",
         "default:prConcurrentLimitNone",
         "default:prHourlyLimitNone",


### PR DESCRIPTION
Switch to the default of `false` for rebasing of stale PRs by the Renovate bot.


## Motivation and Context
This will reduce noise in CI, as frequent merges to master result in many updated branches in projects with many open Renovate PRs.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bugfix
- [x] Feature
- [x] Performance Improvement
- [ ] Tests _(fix, improvement, new tests)_
- [ ] Code style update _(formatting, local variables)_
- [ ] Refactoring _(no functional changes, no api changes)_
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other... Please describe: 